### PR TITLE
CS 0002 - AR Panels not following panoramic view

### DIFF
--- a/src/components/ar/PanoramicView.jsx
+++ b/src/components/ar/PanoramicView.jsx
@@ -59,7 +59,7 @@ export default function PanoramicView({ onClose }) {
             key={panel.id}
             style={{
               ...styles.panel,
-              transform: `rotateY(${panel.angle}deg) translateZ(-420px)`,
+              transform: `rotateY(${panel.angle}deg) translateZ(-360px)`,
               opacity: 1,
               scale: '1',
             }}


### PR DESCRIPTION
# CS 0002 - AR Panels not following panoramic view
**Developer Validity:** 
- [x] I have made sure that my changes did not break anything during development and is ready for staging. 
 
**📝Description** 
- Fixed the panoramic AR view so panels curve inward (concave) around the user's viewpoint instead of extending outward (convex), by negating the translateZ value on panel transforms
- Adjusted panel spacing to ~10mm gaps by tuning the rotation angle (41°) and radius (360px) to prevent overlap while keeping panels visually cohesive
- Removed active panel bias, all three panels now render at equal opacity and scale, removing the dimming/shrinking of non-selected panels and the associated activePanel state

**📷Checklist** 
- [x] Code builds successfully 
- [x] No console errors 
- [x] Linting passes 
- [x] Tests added or updated (if applicable) 
- [x] Environment variables documented  
 
--- 
**📸Screenshots / Proof (if UI related)** 
<img width="842" height="525" alt="image" src="https://github.com/user-attachments/assets/43096d32-bca9-478a-8422-ac84f94afcaa" />
<img width="842" height="525" alt="image" src="https://github.com/user-attachments/assets/43096d32-bca9-478a-8422-ac84f94afcaa" />

Resolves #4 # 